### PR TITLE
Fixed error if user doesn't accept location

### DIFF
--- a/resources/js/components/NewPost.tsx
+++ b/resources/js/components/NewPost.tsx
@@ -27,6 +27,13 @@ function NewPostButton() {
     const { userLocation, loggedIn } = useUserInfo()
 
     const submitClicked = async() => {
+        
+        // if location not available
+        if(!userLocation){
+            console.error("Location not available");
+            alert("Location access is required for you to make a post, please enable your location.");
+            return;
+        }
 
         const content = postTextAreaRef.current?.value as string
 


### PR DESCRIPTION
Added a check before getting the content for a post. Checks for the users location if not found the user sees a message alerting them to enable their location. 